### PR TITLE
Remove custom winssl triplet

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 version: 0.1.0.{build}
-os: Visual Studio 2017
+os: Visual Studio 2019
 cache:
 - C:\vcpkg
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
-  version: 18
+  version: 19
   matrix:
-    - TRIPLET: x86-windows-static-winssl
-    - TRIPLET: x64-windows-static-winssl
+    - TRIPLET: x86-windows-static
+    - TRIPLET: x64-windows-static
 #    - TRIPLET: x86-uwp
 #    - TRIPLET: x64-uwp
 #    - TRIPLET: arm-uwp

--- a/build.bat
+++ b/build.bat
@@ -1,9 +1,9 @@
 pushd vcpkg
 
 REM Install libraries
-.\vcpkg install benchmark:%TRIPLET% breakpad:%TRIPLET% curl:%TRIPLET% discord-rpc:%TRIPLET% freetype:%TRIPLET% jansson:%TRIPLET% libpng:%TRIPLET% libzip:%TRIPLET% openssl:%TRIPLET% sdl2:%TRIPLET% speexdsp:%TRIPLET% zlib:%TRIPLET%
+.\vcpkg install benchmark:%TRIPLET% breakpad:%TRIPLET% curl[winssl]:%TRIPLET% discord-rpc:%TRIPLET% freetype:%TRIPLET% jansson:%TRIPLET% libpng:%TRIPLET% libzip:%TRIPLET% openssl:%TRIPLET% sdl2:%TRIPLET% speexdsp:%TRIPLET% zlib:%TRIPLET%
 
 REM Export libraries
-.\vcpkg export benchmark:%TRIPLET% breakpad:%TRIPLET% curl:%TRIPLET% discord-rpc:%TRIPLET% freetype:%TRIPLET% jansson:%TRIPLET% libpng:%TRIPLET% libzip:%TRIPLET% openssl:%TRIPLET% sdl2:%TRIPLET% speexdsp:%TRIPLET% zlib:%TRIPLET% --zip --nuget
+.\vcpkg export benchmark:%TRIPLET% breakpad:%TRIPLET% curl[winssl]:%TRIPLET% discord-rpc:%TRIPLET% freetype:%TRIPLET% jansson:%TRIPLET% libpng:%TRIPLET% libzip:%TRIPLET% openssl:%TRIPLET% sdl2:%TRIPLET% speexdsp:%TRIPLET% zlib:%TRIPLET% --zip --nuget
 
 popd

--- a/triplets/x64-windows-static-winssl.cmake
+++ b/triplets/x64-windows-static-winssl.cmake
@@ -1,6 +1,0 @@
-# Based on upstream x64-windows-static.cmake
-set(VCPKG_TARGET_ARCHITECTURE x64)
-set(VCPKG_CRT_LINKAGE static)
-set(VCPKG_LIBRARY_LINKAGE static)
-# Make curl use winssl
-set(CURL_USE_WINSSL ON)

--- a/triplets/x86-windows-static-winssl.cmake
+++ b/triplets/x86-windows-static-winssl.cmake
@@ -1,6 +1,0 @@
-# Based on upstream x86-windows-static.cmake
-set(VCPKG_TARGET_ARCHITECTURE x86)
-set(VCPKG_CRT_LINKAGE static)
-set(VCPKG_LIBRARY_LINKAGE static)
-# Make curl use winssl
-set(CURL_USE_WINSSL ON)


### PR DESCRIPTION
vcpkg now has package install options, so use winssl option for curl instead of triplet.