### PR TITLE
vcpkg dependency builds for macOS

### DIFF
--- a/dummy-port/portfile.cmake
+++ b/dummy-port/portfile.cmake
@@ -1,0 +1,3 @@
+set(VERSION 1.2.11)
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/dummy-port/portfile.cmake
+++ b/dummy-port/portfile.cmake
@@ -1,3 +1,1 @@
-set(VERSION 1.2.11)
-
 set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -2,9 +2,8 @@
 
 easy_install --user pyyaml
 
-#git clone -q https://github.com/Microsoft/vcpkg.git
-git clone -q https://github.com/LRFLEW/vcpkg.git
-git -C vcpkg checkout openrct2-devel
+git clone -q https://github.com/Microsoft/vcpkg.git
+git -C vcpkg apply ../vcpkg_fixup_pkgconfig.cmake.diff
 
 vcpkg/bootstrap-vcpkg.sh
 
@@ -12,6 +11,7 @@ TRIPLET="--overlay-triplets=. --triplet=x64-osx-openrct2"
 LIBRARIES="duktape freetype libpng libzip[core] nlohmann-json openssl sdl2 speexdsp"
 vcpkg/vcpkg install ${=TRIPLET} ${=LIBRARIES}  
 
-pushd vcpkg/installed/x64-osx-openrct2
-zip -rXy ../../../openrct2-libs-v27-x64-macos-dylibs.zip * -x '*/.*'
-popd
+(
+  cd vcpkg/installed/x64-osx-openrct2 &&
+  zip -rXy ../../../openrct2-libs-v${version}-x64-macos-dylibs.zip * -x '*/.*'
+)

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -8,7 +8,7 @@ git -C vcpkg apply ../vcpkg_fixup_pkgconfig.cmake.diff
 vcpkg/bootstrap-vcpkg.sh
 
 TRIPLET="--overlay-triplets=. --triplet=x64-osx-openrct2"
-LIBRARIES="duktape freetype libpng libzip[core] nlohmann-json openssl sdl2 speexdsp"
+LIBRARIES="duktape freetype libpng libzip[core] nlohmann-json openssl sdl2 speexdsp discord-rpc"
 vcpkg/vcpkg install ${=TRIPLET} ${=LIBRARIES}  
 
 (

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -11,3 +11,7 @@ vcpkg/bootstrap-vcpkg.sh
 TRIPLET="--overlay-triplets=. --triplet=x64-osx-openrct2"
 LIBRARIES="duktape freetype libpng libzip[core] nlohmann-json openssl sdl2 speexdsp"
 vcpkg/vcpkg install ${=TRIPLET} ${=LIBRARIES}  
+
+pushd vcpkg/installed/x64-osx-openrct2
+zip -rXy ../../../openrct2-libs-v27-x64-macos-dylibs.zip * -x '*/.*'
+popd

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -1,10 +1,11 @@
 #!/bin/zsh
 
+brew install libyaml
+sudo easy_install pyyaml
+
 git clone -q https://github.com/Microsoft/vcpkg.git
 vcpkg/bootstrap-vcpkg.sh
 
-TRIPLET=""
-LIBRARIES=""
-vcpkg/vcpkg install \
-  --overlay-triplets=. --triplet=x64-osx-openrct2 \
-  freetype libpng 'libzip[core]' nlohmann-json sdl2
+TRIPLET="--overlay-triplets=. --triplet=x64-osx-openrct2"
+LIBRARIES="duktape freetype libpng libzip[core] nlohmann-json sdl2"
+vcpkg/vcpkg install ${=TRIPLET} ${=LIBRARIES}  

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -1,11 +1,13 @@
 #!/bin/zsh
 
-brew install libyaml
-sudo easy_install pyyaml
+easy_install --user pyyaml
 
-git clone -q https://github.com/Microsoft/vcpkg.git
+#git clone -q https://github.com/Microsoft/vcpkg.git
+git clone -q https://github.com/LRFLEW/vcpkg.git
+git -C vcpkg checkout openrct2-devel
+
 vcpkg/bootstrap-vcpkg.sh
 
 TRIPLET="--overlay-triplets=. --triplet=x64-osx-openrct2"
-LIBRARIES="duktape freetype libpng libzip[core] nlohmann-json sdl2"
+LIBRARIES="duktape freetype libpng libzip[core] nlohmann-json openssl sdl2 speexdsp"
 vcpkg/vcpkg install ${=TRIPLET} ${=LIBRARIES}  

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -8,7 +8,7 @@ git -C vcpkg apply ../vcpkg_fixup_pkgconfig.cmake.diff
 vcpkg/bootstrap-vcpkg.sh
 
 TRIPLET="--overlay-triplets=. --triplet=x64-osx-openrct2"
-LIBRARIES="duktape freetype libpng libzip[core] nlohmann-json openssl sdl2 speexdsp discord-rpc"
+LIBRARIES="duktape freetype[core,zlib,bzip2,png] libpng libzip[core] nlohmann-json openssl sdl2 speexdsp discord-rpc"
 vcpkg/vcpkg install ${=TRIPLET} ${=LIBRARIES}  
 
 (

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -1,0 +1,10 @@
+#!/bin/zsh
+
+git clone -q https://github.com/Microsoft/vcpkg.git
+vcpkg/bootstrap-vcpkg.sh
+
+TRIPLET=""
+LIBRARIES=""
+vcpkg/vcpkg install \
+  --overlay-triplets=. --triplet=x64-osx-openrct2 \
+  freetype libpng 'libzip[core]' nlohmann-json sdl2

--- a/macos_pkgconfig/bzip2.pc
+++ b/macos_pkgconfig/bzip2.pc
@@ -1,0 +1,12 @@
+prefix=/usr
+
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: bzip2
+Version: 1.0.5
+Requires: 
+Libs: -L${libdir} -lbz2
+Cflags: -I${includedir}

--- a/macos_pkgconfig/zlib.pc
+++ b/macos_pkgconfig/zlib.pc
@@ -1,0 +1,14 @@
+prefix=/usr
+
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+sharedlibdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: zlib
+Description: zlib compression library
+Version: 1.2.11
+
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -lz
+Cflags: -I${includedir}

--- a/vcpkg_fixup_pkgconfig.cmake.diff
+++ b/vcpkg_fixup_pkgconfig.cmake.diff
@@ -1,0 +1,28 @@
+diff --git a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+index baccef100..7f0dc464d 100644
+--- a/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
++++ b/scripts/cmake/vcpkg_fixup_pkgconfig.cmake
+@@ -50,8 +50,8 @@ function(vcpkg_fixup_pkgconfig_check_files pkg_cfg_cmd _file _config _system_lib
+     set(PKGCONFIG_PACKAGES_DIR "${_VCPKG_PACKAGES_PKGCONF}${PATH_SUFFIX_${_config}}/lib/pkgconfig")
+     set(PKGCONFIG_PACKAGES_SHARE_DIR "${_VCPKG_PACKAGES_PKGCONF}/share/pkgconfig")
+ 
+-    if(ENV{PKG_CONFIG_PATH})
+-        set(BACKUP_ENV_PKG_CONFIG_PATH_${_config} $ENV{PKG_CONFIG_PATH})
++    if(DEFINED ENV{PKG_CONFIG_PATH})
++        set(BACKUP_ENV_PKG_CONFIG_PATH_${_config} "$ENV{PKG_CONFIG_PATH}")
+         set(ENV{PKG_CONFIG_PATH} "${PKGCONFIG_INSTALLED_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_INSTALLED_SHARE_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_PACKAGES_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_PACKAGES_SHARE_DIR}${VCPKG_HOST_PATH_SEPARATOR}$ENV{PKG_CONFIG_PATH}")
+     else()
+         set(ENV{PKG_CONFIG_PATH} "${PKGCONFIG_INSTALLED_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_INSTALLED_SHARE_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_PACKAGES_DIR}${VCPKG_HOST_PATH_SEPARATOR}${PKGCONFIG_PACKAGES_SHARE_DIR}")
+@@ -237,6 +237,12 @@ function(vcpkg_fixup_pkgconfig_check_files pkg_cfg_cmd _file _config _system_lib
+     endforeach()
+ 
+     set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BACKUP})
++    if(DEFINED BACKUP_ENV_PKG_CONFIG_PATH_${_config})
++        set(ENV{PKG_CONFIG_PATH} "${BACKUP_ENV_PKG_CONFIG_PATH_${_config}}")
++        unset(BACKUP_ENV_PKG_CONFIG_PATH_${_config})
++    else()
++        unset(ENV{PKG_CONFIG_PATH})
++    endif()
+ endfunction()
+ 
+ function(vcpkg_fixup_pkgconfig)

--- a/x64-osx-openrct2.cmake
+++ b/x64-osx-openrct2.cmake
@@ -3,6 +3,9 @@ set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_DEPLOYMENT_TARGET "10.13")
+
+set(VCPKG_BUILD_TYPE release)
 
 #if(PORT STREQUAL "zlib" OR PORT STREQUAL "bzip2")
 #    set(CURRENT_PORT_DIR "../dummy-port")

--- a/x64-osx-openrct2.cmake
+++ b/x64-osx-openrct2.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+
+#if(PORT STREQUAL "zlib" OR PORT STREQUAL "bzip2")
+#    set(CURRENT_PORT_DIR "../dummy-port")
+#endif()

--- a/x64-osx-openrct2.cmake
+++ b/x64-osx-openrct2.cmake
@@ -1,12 +1,21 @@
+cmake_policy(SET CMP0057 NEW)
+
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
 set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_DEPLOYMENT_TARGET "10.13")
-
 set(VCPKG_BUILD_TYPE release)
 
-#if(PORT STREQUAL "zlib" OR PORT STREQUAL "bzip2")
-#    set(CURRENT_PORT_DIR "../dummy-port")
-#endif()
+if(DEFINED ENV{PKG_CONFIG_PATH})
+    set(ENV{PKG_CONFIG_PATH} "${CMAKE_CURRENT_LIST_DIR}/macos_pkgconfig:$ENV{PKG_CONFIG_PATH}")
+else()
+    set(ENV{PKG_CONFIG_PATH} "${CMAKE_CURRENT_LIST_DIR}/macos_pkgconfig")
+endif()
+
+list(APPEND VCPKG_SYSTEM_LIBRARIES "z" "bz2")
+set(OPENRCT2_SYSTEM_PACKAGES "zlib" "bzip2")
+if(PORT IN_LIST OPENRCT2_SYSTEM_PACKAGES)
+    set(CURRENT_PORT_DIR "${CMAKE_CURRENT_LIST_DIR}/dummy-port")
+endif()


### PR DESCRIPTION
It's been a while. Since my last PR to vcpkg was finally closed, I've been trying to get this working. This is using vcpkg a bit outside of the supported use case (macOS dynamic library builds are not *officially* supported), but it seems to be stable enough that it shouldn't be a huge issue. I got a number of the dependencies working, but some will require port updates in vcpkg to work correctly. Here's the current status of what I'm missing:

- [x] `duktape` ~~(depends on https://github.com/microsoft/vcpkg/pull/14662)~~ ~~(soft depends on https://github.com/microsoft/vcpkg/pull/14666)~~ (soft depends on https://github.com/microsoft/vcpkg/issues/14741)
- [x] `speexdsp` ~~(depends on https://github.com/microsoft/vcpkg/pull/14758)~~
- [x] `openssl` ~~(depends on https://github.com/microsoft/vcpkg/pull/14785)~~
- [x] System `zlib` and `bzip2` (depends on https://github.com/microsoft/vcpkg/pull/14799)
- [x] Remove brotli from build ~~(depends on https://github.com/microsoft/vcpkg/pull/14917)~~

I haven't been following the changes in the project much recently, so I might be very likely missing something. I think I have everything based on the current dependencies release for macOS. With this change, it could also be an opportunity to add other dependencies that have been on a "wishlist", such as `discord-rpc`, so let me know if there's anything else you want me to look into for this.