### PR TITLE
remove brotli from freetype options (macos)

### DIFF
--- a/macos_build.sh
+++ b/macos_build.sh
@@ -15,7 +15,7 @@ fi
 vcpkg/bootstrap-vcpkg.sh
 
 TRIPLET="--overlay-triplets=. --triplet=x64-osx-openrct2"
-LIBRARIES="duktape freetype libpng libzip[core] nlohmann-json openssl sdl2 speexdsp discord-rpc icu"
+LIBRARIES="duktape freetype[core,zlib,bzip2,png] libpng libzip[core] nlohmann-json openssl sdl2 speexdsp discord-rpc icu"
 vcpkg/vcpkg install ${=TRIPLET} ${=LIBRARIES}
 
 (


### PR DESCRIPTION
@IntelOrca can we get one more release please? This removes a late breaking addition to the last Dependencies release that wasn't fully vetted. This is what caused issues with pointing Xcode builds to the new dependencies release, since freetype is only used by the UI. Freetype was not previously linked against brotli on macOS, and as it is not strictly required for any functionality, we'll remove it for now. If @LRFLEW or I are able to patch the brotli port in vcpkg upstream, then we can add this back.