### PR TITLE
pin pyyaml to python2 compatible version

### DIFF
--- a/macos_build.sh
+++ b/macos_build.sh
@@ -3,7 +3,7 @@
 # exit on error
 set -e
 
-easy_install --user pyyaml
+easy_install --user pyyaml==5.4.1 
 
 git clone -q https://github.com/Microsoft/vcpkg.git
 


### PR DESCRIPTION
Well...not related to my last change...but also a one line fix as I hoped.

Looks like https://pypi.org/project/PyYAML/6.0b1/#history was released on pypi on Monday (which drops python2.7 support: https://github.com/yaml/pyyaml/pull/550) - just in time to wreak havoc here! I've added an explicit version pin to 5.4.1. Hopefully, duktape will eventually be updated to be python3 compatible - looks like the vcpkg folks are interested in https://github.com/svaarala/duktape/issues/1794 as well! (The vcpkg port attempts to install pyyaml if it is not present, but it falls into the same trap now, so removing this separate install step was not successful.)

@tupaschoal mind giving this another go? Thanks!