### PR TITLE
Bump vcpkg pin to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 env:
-  VCPKG_COMMIT_HASH: c26477297ce1a9d67844e86bf0cda0e7741bd169
+  VCPKG_COMMIT_HASH: 5cf60186a241e84e8232641ee973395d4fde90e1
 jobs:
   createrelease:
     name: createrelease

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
         shell: bash
         run: |
           export VCPKG_COMMIT_HASH='${{ env.VCPKG_COMMIT_HASH }}'
+          brew install automake
           ./macos_build.sh
       - name: Upload zip as artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
sdl2 is now on 2.0.20, which should have the upstream fix for https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2-ui/CMakeLists.txt#L39-L45

Can we get a new release that bumps this pin to latest, and then I'll try pulling out the workaround?