### PR TITLE
Update vcpkg to current version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 env:
-  VCPKG_COMMIT_HASH: 5e7cbdceacd2b3cb85e057963fdb605136805bd3
+  VCPKG_COMMIT_HASH: 23f0707b1a46bbf7fff9fb95cde2aa0c7213c31d
 jobs:
   createrelease:
     name: createrelease

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 env:
-  VCPKG_COMMIT_HASH: 23f0707b1a46bbf7fff9fb95cde2aa0c7213c31d
+  VCPKG_COMMIT_HASH: c9f906558f9bb12ee9811d6edc98ec9255c6cda5
 jobs:
   createrelease:
     name: createrelease

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -18,7 +18,7 @@ vcpkg/bootstrap-vcpkg.sh
 
 ARM_TRIPLET="--overlay-triplets=. --triplet=arm64-osx-openrct2"
 X64_TRIPLET="--overlay-triplets=. --triplet=x64-osx-openrct2"
-LIBRARIES="libpng freetype openssl icu libzip[core] nlohmann-json openal-soft sdl2 speexdsp discord-rpc gtest libflac libogg libvorbis"
+LIBRARIES="libpng freetype openssl icu[core,tools] libzip[core] nlohmann-json openal-soft sdl2 speexdsp discord-rpc gtest libflac libogg libvorbis"
 vcpkg/vcpkg install ${=ARM_TRIPLET} ${=LIBRARIES}
 vcpkg/vcpkg install ${=X64_TRIPLET} ${=LIBRARIES}
 


### PR DESCRIPTION
Updates:
- benchmark 1.6.1 -> 1.7.1
- breakpad 2020-09-14 -> 2022-07-12
- discord-rpc 3.4.0 (no change)
- freetype 2.11.1 -> 2.12.1
- fribidi 1.0.12 (no change)
- gtest 1.11.0 -> 1.13.0
- libflac 1.3.4 -> 1.4.2
- libogg 1.3.5 (no change)
- libvorbis 1.3.7 (no change)
- libpng 1.6.37 -> 1.6.39
- libzip 1.8.0 -> 1.9.2
- nlohmann-json 3.10.5 -> 3.11.2
- openal-soft 1.21.1 -> 1.23.0
- SDL 2.0.22 -> 2.26.4
- speexdsp 1.2.0 -> 1.2.1
- zlib 1.2.12 -> 1.2.13