### PR TITLE
Use vcpkg in manifest mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/v')
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Get the version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Download All Artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
           runVcpkgInstall: true
       - name: Zip stuff
         run: |
-          pushd ${{ github.workspace }}/vcpkg/installed/${{ matrix.triplet }}
-          7z a -tzip -mx9 -mtc=off ..\openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip "*"
+          pushd ${{ github.workspace }}/vcpkg/installed/${{ matrix.triplet }}/${{ matrix.triplet }}
+          7z a -tzip -mx9 -mtc=off ../../openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip "*"
           popd
       - name: Upload zip as artifact
         uses: actions/upload-artifact@v4
@@ -79,7 +79,7 @@ jobs:
         id: get_release_info
         shell: bash
         run: |
-          value=`cat release_url/release_url.txt`
+          value=`cat release_url.txt`
           echo "upload_url=$value" >> $GITHUB_OUTPUT
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/v')
@@ -171,7 +171,7 @@ jobs:
         id: get_release_info
         shell: bash
         run: |
-          value=`cat release_url/release_url.txt`
+          value=`cat release_url.txt`
           echo "upload_url=$value" >> $GITHUB_OUTPUT
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
-      - name: create release
+      - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ env.version }}
-          release_name: Release v${{ env.version }}
+          name: Release v${{ env.version }}
           prerelease: false
       - name: Output Release URL File
         run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         run: |
           value=`cat release_url/release_url.txt`
-          echo ::set-output name=upload_url::$value
+          echo "upload_url=$value" >> $GITHUB_OUTPUT
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/v')
         id: upload-release-asset
@@ -169,7 +169,7 @@ jobs:
         shell: bash
         run: |
           value=`cat release_url/release_url.txt`
-          echo ::set-output name=upload_url::$value
+          echo "upload_url=$value" >> $GITHUB_OUTPUT
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/v')
         id: upload-release-asset

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 env:
-  VCPKG_COMMIT_HASH: c9f906558f9bb12ee9811d6edc98ec9255c6cda5
+  VCPKG_COMMIT_HASH: 11ed79186fe850bd3a98cfbf1854514d2b3070a2
 jobs:
   createrelease:
     name: createrelease
@@ -9,7 +9,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get the version
         id: get_version
         run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
@@ -25,7 +25,7 @@ jobs:
       - name: Output Release URL File
         run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
       - name: Save Release URL File for publish
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: release_url
           path: release_url.txt
@@ -39,40 +39,39 @@ jobs:
       matrix:
         include:
           - triplet: x86-windows-static
-            vcpkgPackages: 'benchmark breakpad discord-rpc freetype fribidi gtest libpng libzip[core] nlohmann-json openal-soft sdl2 speexdsp zlib libflac libogg libvorbis'
           - triplet: x64-windows-static
-            vcpkgPackages: 'benchmark breakpad discord-rpc freetype fribidi gtest libpng libzip[core] nlohmann-json openal-soft sdl2 speexdsp zlib libflac libogg libvorbis'
           - triplet: arm64-windows-static
-            # fribidi is disabled due to https://github.com/microsoft/vcpkg/issues/11248 [fribidi] Fribidi doesn't cross-compile on x86-64 to target arm/arm64
-            vcpkgPackages: 'benchmark discord-rpc freetype gtest libpng libzip[core] nlohmann-json openal-soft sdl2 speexdsp zlib libflac libogg libvorbis'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get the version
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           chcp 65001 #set code page to utf-8
           echo ("version=" + $env:GITHUB_REF.replace('refs/tags/v', '')) >> $env:GITHUB_ENV
+      - uses: lukka/get-cmake@latest
       - name: Install vcpkg and packages
-        uses: lukka/run-vcpkg@v6
+        uses: lukka/run-vcpkg@v11
         id: runvcpkg
+        env:
+          VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+          VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg/installed/${{ matrix.triplet }}
         with:
           vcpkgGitCommitId: '${{ env.VCPKG_COMMIT_HASH }}'
-          vcpkgTriplet: '${{ matrix.triplet }}'
-          vcpkgArguments: '${{ matrix.vcpkgPackages }}'
+          runVcpkgInstall: true
       - name: Zip stuff
         run: |
-          pushd ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\${{ matrix.triplet }}
+          pushd ${{ github.workspace }}/vcpkg/installed/${{ matrix.triplet }}
           7z a -tzip -mx9 -mtc=off ..\openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip "*"
           popd
       - name: Upload zip as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
-          path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
+          path: ${{ github.workspace }}/vcpkg/installed/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
       - name: Load Release URL File from release job
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: release_url
       - name: Get Release File Name & Upload URL
@@ -90,35 +89,78 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}\\installed\\openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
+          asset_path: ${{ github.workspace }}/vcpkg/installed/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
           asset_name: openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
           asset_content_type: application/zip
-  macos:
+  macos-build:
     name: macOS
     runs-on: macos-latest
     needs: createrelease
     if: always()
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - triplet: arm64-osx-openrct2
+          - triplet: x64-osx-openrct2
     steps:
+      # needed for vcpkg.json
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get the version
         if: startsWith(github.ref, 'refs/tags/v')
         run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
-      - name: Install vcpkg and packages
-        id: macos_build
+      - name: Install prerequisites
         shell: bash
         run: |
-          export VCPKG_COMMIT_HASH='${{ env.VCPKG_COMMIT_HASH }}'
           brew install automake autoconf-archive
+      - uses: lukka/get-cmake@latest
+      - name: Install vcpkg and packages
+        uses: lukka/run-vcpkg@v11
+        id: runvcpkg
+        env:
+          VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+          VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg/installed/${{ matrix.triplet }}
+        with:
+          vcpkgGitCommitId: '${{ env.VCPKG_COMMIT_HASH }}'
+          runVcpkgInstall: true
+          # needed for --overlay-triplets option
+          runVcpkgFormatString: '[`install`, `--recurse`, `--clean-after-build`, `--x-install-root`, `$[env.VCPKG_INSTALLED_DIR]`, `--overlay-triplets=.`, `--triplet`, `$[env.VCPKG_DEFAULT_TRIPLET]`]'
+      - name: Zip stuff
+        run: |
+          pushd ${{ github.workspace }}/vcpkg/installed/${{ matrix.triplet }}
+          zip -rXy ../openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}-macos-dylibs.zip * -x '*/.*'
+      - name: Upload zip as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}-macos-dylibs.zip
+          path: ${{ github.workspace }}/vcpkg/installed/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}-macos-dylibs.zip
+
+  macos-package:
+    name: macOS package universal library
+    runs-on: macos-latest
+    needs: macos-build
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: openrct2-libs-v*-macos-dylibs.zip
+      - name: Create Universal Library
+        run: |
+          unzip -qo openrct2-libs-v${{ env.version }}-arm64-osx-openrct2-macos-dylibs.zip/openrct2-libs-v${{ env.version }}-arm64-osx-openrct2-macos-dylibs.zip
+          unzip -qo openrct2-libs-v${{ env.version }}-x64-osx-openrct2-macos-dylibs.zip/openrct2-libs-v${{ env.version }}-x64-osx-openrct2-macos-dylibs.zip
           ./macos_build.sh
       - name: Upload zip as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: openrct2-libs-v${{ env.version }}-universal-macos-dylibs.zip
           path: openrct2-libs-v${{ env.version }}-universal-macos-dylibs.zip
       - name: Load Release URL File from release job
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: release_url
       - name: Get Release File Name & Upload URL

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -3,27 +3,8 @@
 # exit on error
 set -e
 
-easy_install --user pyyaml==5.4.1 
-
-git clone -q https://github.com/Microsoft/vcpkg.git
-
-if [ -v VCPKG_COMMIT_HASH ]; then
-  echo "Using pinned vcpkg commit: ${VCPKG_COMMIT_HASH}"
-  pushd vcpkg
-  git checkout -q $VCPKG_COMMIT_HASH
-  popd
-fi
-
-vcpkg/bootstrap-vcpkg.sh
-
-ARM_TRIPLET="--overlay-triplets=. --triplet=arm64-osx-openrct2"
-X64_TRIPLET="--overlay-triplets=. --triplet=x64-osx-openrct2"
-LIBRARIES="libpng freetype openssl icu[core,tools] libzip[core] nlohmann-json openal-soft sdl2 speexdsp discord-rpc gtest libflac libogg libvorbis"
-vcpkg/vcpkg install ${=ARM_TRIPLET} ${=LIBRARIES}
-vcpkg/vcpkg install ${=X64_TRIPLET} ${=LIBRARIES}
-
-rsync -ah vcpkg/installed/x64-osx-openrct2/* universal-osx-openrct2
-for lib in vcpkg/installed/x64-osx-openrct2/lib/*.dylib; do
+rsync -ah x64-osx-openrct2/* universal-osx-openrct2
+for lib in x64-osx-openrct2/lib/*.dylib; do
     if [ -f "$lib" ] && [ ! -L $lib ]; then
       lib_filename=$(basename "$lib")
       lib_name=$(echo $lib_filename | cut -d'.' -f 1)
@@ -32,12 +13,12 @@ for lib in vcpkg/installed/x64-osx-openrct2/lib/*.dylib; do
         # libzip embeds the full rpath in LC_RPATH
         # they will be different for arm64 and x86_64
         # this will cause issues, and is unnecessary
-        install_name_tool -delete_rpath `pwd`"/vcpkg/packages/${lib_name}_x64-osx-openrct2/lib" "vcpkg/installed/x64-osx-openrct2/lib/$lib_filename"
-        install_name_tool -delete_rpath `pwd`"/vcpkg/installed/x64-osx-openrct2/lib" "vcpkg/installed/x64-osx-openrct2/lib/$lib_filename"
-        install_name_tool -delete_rpath `pwd`"/vcpkg/packages/${lib_name}_arm64-osx-openrct2/lib" "vcpkg/installed/arm64-osx-openrct2/lib/$lib_filename"
-        install_name_tool -delete_rpath `pwd`"/vcpkg/installed/arm64-osx-openrct2/lib" "vcpkg/installed/arm64-osx-openrct2/lib/$lib_filename"
+        install_name_tool -delete_rpath `pwd`"/vcpkg/packages/${lib_name}_x64-osx-openrct2/lib" "x64-osx-openrct2/lib/$lib_filename"
+        install_name_tool -delete_rpath `pwd`"/vcpkg/installed/x64-osx-openrct2/x64-osx-openrct2/lib" "x64-osx-openrct2/lib/$lib_filename"
+        install_name_tool -delete_rpath `pwd`"/vcpkg/packages/${lib_name}_arm64-osx-openrct2/lib" "arm64-osx-openrct2/lib/$lib_filename"
+        install_name_tool -delete_rpath `pwd`"/vcpkg/installed/arm64-osx-openrct2/arm64-osx-openrct2/lib" "arm64-osx-openrct2/lib/$lib_filename"
       fi
-      lipo -create "vcpkg/installed/x64-osx-openrct2/lib/$lib_filename" "vcpkg/installed/arm64-osx-openrct2/lib/$lib_filename" -output "universal-osx-openrct2/lib/$lib_filename"
+      lipo -create "x64-osx-openrct2/lib/$lib_filename" "arm64-osx-openrct2/lib/$lib_filename" -output "universal-osx-openrct2/lib/$lib_filename"
     fi
 done
 

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -9,15 +9,39 @@ for lib in x64-osx-openrct2/lib/*.dylib; do
       lib_filename=$(basename "$lib")
       lib_name=$(echo $lib_filename | cut -d'.' -f 1)
       echo "Creating universal (fat) $lib_name"
-      if [ "$lib_name" = "libzip" ]; then
-        # libzip embeds the full rpath in LC_RPATH
-        # they will be different for arm64 and x86_64
-        # this will cause issues, and is unnecessary
-        install_name_tool -delete_rpath `pwd`"/vcpkg/packages/${lib_name}_x64-osx-openrct2/lib" "x64-osx-openrct2/lib/$lib_filename"
-        install_name_tool -delete_rpath `pwd`"/vcpkg/installed/x64-osx-openrct2/x64-osx-openrct2/lib" "x64-osx-openrct2/lib/$lib_filename"
-        install_name_tool -delete_rpath `pwd`"/vcpkg/packages/${lib_name}_arm64-osx-openrct2/lib" "arm64-osx-openrct2/lib/$lib_filename"
-        install_name_tool -delete_rpath `pwd`"/vcpkg/installed/arm64-osx-openrct2/arm64-osx-openrct2/lib" "arm64-osx-openrct2/lib/$lib_filename"
-      fi
+      for arch in x64 arm64; do
+        if [[ "$lib_name" = "libzip" || $lib_name = libicu* ]]; then
+          # libzip embeds the full rpath in LC_RPATH
+          # they will be different for arm64 and x86_64
+          # this will cause issues, and is unnecessary
+          echo Fixing $lib_name rpath
+          install_name_tool -delete_rpath `pwd`"/vcpkg/packages/${lib_name}_$arch-osx-openrct2/lib" "$arch-osx-openrct2/lib/$lib_filename" || echo No `pwd`"/vcpkg/packages/${lib_name}_$arch-osx-openrct2/lib" in $lib
+          install_name_tool -delete_rpath `pwd`"/vcpkg/installed/$arch-osx-openrct2/$arch-osx-openrct2/lib" "$arch-osx-openrct2/lib/$lib_filename" || echo No `pwd`"/vcpkg/installed/$arch-osx-openrct2/$arch-osx-openrct2/lib" in $lib
+        fi
+        if [[ "$lib_name" = libbrotli* ]]; then
+          # Brotli uses full path for LC_ID_DYLIB, which breaks when trying to fix up LC_LOAD_DYLIB in next step.
+          # Fix the LC_ID_DYLIB first before fixing up the LC_LOAD_DYLIB.
+          echo Fixing $lib_name LC_ID_DYLIB
+          install_name_tool -id "@rpath/$lib_filename" "$arch-osx-openrct2/lib/$lib_filename"
+        fi
+        if otool -L $arch-osx-openrct2/lib/$lib_filename | grep -q /Users/runner/work/; then
+          echo "Absolute paths found in $arch-osx-openrct2/lib/$lib_filename. Load commands:"
+          otool -L "$arch-osx-openrct2/lib/$lib_filename"
+          # Some packages (currently only brotli) have absolute paths in the LC_LOAD_DYLIB command.
+          # This is not supported by the universal build and needs to be changes to @rpath.
+
+          install_name_tool -change /Users/runner/work/Dependencies/Dependencies/vcpkg/packages/brotli_$arch-osx-openrct2/lib/libbrotlicommon.1.dylib "@rpath/libbrotlicommon.1.dylib" "$arch-osx-openrct2/lib/$lib_filename"
+          install_name_tool -change /Users/runner/work/Dependencies/Dependencies/vcpkg/packages/brotli_$arch-osx-openrct2/lib/libbrotlidec.1.dylib "@rpath/libbrotlidec.1.dylib" "$arch-osx-openrct2/lib/$lib_filename"
+          install_name_tool -change /Users/runner/work/Dependencies/Dependencies/vcpkg/packages/brotli_$arch-osx-openrct2/lib/libbrotlienc.1.dylib "@rpath/libbrotlienc.1.dylib" "$arch-osx-openrct2/lib/$lib_filename"
+
+          # Once done, check that it was the only absolute path in the LC_LOAD_DYLIB command.
+          if otool -L "$arch-osx-openrct2/lib/$lib_filename" | grep -q /Users/runner/work; then
+            echo "Absolute paths still exist in $arch-osx-openrct2/lib/$lib_filename. Load commands:"
+            otool -L $arch-osx-openrct2/lib/$lib_filename
+            exit 1
+          fi
+        fi
+      done
       lipo -create "x64-osx-openrct2/lib/$lib_filename" "arm64-osx-openrct2/lib/$lib_filename" -output "universal-osx-openrct2/lib/$lib_filename"
     fi
 done

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -49,4 +49,5 @@ done
 (
   cd universal-osx-openrct2 &&
   zip -rXy ../openrct2-libs-v${version}-universal-macos-dylibs.zip * -x '*/.*'
+  shasum ../openrct2-libs-v${version}-universal-macos-dylibs.zip
 )

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,42 @@
+{
+    "name": "openrct2-dependencies",
+    "version-string": "11",
+    "description": "Dependencies for OpenRCT2",
+    "dependencies": [
+        "benchmark",
+        {
+            "name": "breakpad",
+            "platform": "windows & !arm"
+        },
+        "discord-rpc",
+        "freetype",
+        {
+            "$explanation": "fribidi is disabled on arm due to https://github.com/microsoft/vcpkg/issues/11248 [fribidi] Fribidi doesn't cross-compile on x86-64 to target arm/arm64",
+            "name": "fribidi",
+            "platform": "!arm & !osx"
+        },
+        "gtest",
+        {
+            "name": "icu",
+            "features": [ "tools" ],
+            "platform": "!windows"
+        },
+        "libflac",
+        "libogg",
+        "libpng",
+        "libvorbis",
+        {
+            "name": "libzip",
+            "default-features": false
+        },
+        "nlohmann-json",
+        "openal-soft",
+        {
+            "name": "openssl",
+            "platform": "!windows"
+        },
+        "sdl2",
+        "speexdsp",
+        "zlib"
+    ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -32,7 +32,7 @@
         "nlohmann-json",
         "openal-soft",
         {
-            "name": "openssl",
+            "name": "libressl",
             "platform": "!windows"
         },
         "sdl2",


### PR DESCRIPTION
This updates our usage of vcpkg from "classic" to "manifest" mode. [Manifest mode](https://learn.microsoft.com/en-us/vcpkg/concepts/manifest-mode) uses `vcpkg.json` to detect which packages are needed.

I encountered several issues when doing that switch, initially planned for Windows only:
1. vcpkg auto-detects presence of `vcpkg.json`, prompting me to update macos jobs at the same time
2. many packages changed, some no longer build cleanly for universal macos and required manual cleanup of `LC_ID_DYLIB`, `LC_RPATH`, `LC_LOAD_DYLIB`. Inspired by code already present for libzip, I updated freetype/brotli and left checks in place to detect possible issues of that kind in the future
3. I updated all the actions used to current versions
4. Got annoyed with the turn-around times for building macos packages and split arm64 and x86_64 builds into their own jobs to be done in parallel
5. Due to issues with building OpenSSL, I switched to LibreSSL, which is quite well supported and API-compatible with OpenSSL.

I have requested users to test macos builds with those libraries and they came back positive. Tests included:
1. master server listing
2. joining multiplayer
3. using TTF (so CJK languages should work no worse than in regular version)
4. sounds playing correctly
5. screenshot working
6. if discord-rpc worked earlier for you, then that as well

I tested Windows builds with updated libraries myself.