### PR TITLE
Rework releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,22 +13,6 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
-      - name: Create release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ env.version }}
-          name: Release v${{ env.version }}
-          prerelease: false
-      - name: Output Release URL File
-        run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
-      - name: Save Release URL File for publish
-        uses: actions/upload-artifact@v4
-        with:
-          name: release_url
-          path: release_url.txt
   windows:
     name: Windows
     runs-on: windows-latest
@@ -64,34 +48,21 @@ jobs:
           pushd ${{ github.workspace }}/vcpkg/installed/${{ matrix.triplet }}/${{ matrix.triplet }}
           7z a -tzip -mx9 -mtc=off ../../openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip "*"
           popd
-      - name: Upload zip as artifact
+      - name: Export checksum info for release notes
+        run: |
+          pushd ${{ github.workspace }}/vcpkg
+          sha1sum installed/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip > ../openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip.sha1
+          popd
+      - name: Upload zipped libraries as artifact
         uses: actions/upload-artifact@v4
         with:
           name: openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
           path: ${{ github.workspace }}/vcpkg/installed/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
-      - name: Load Release URL File from release job
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/download-artifact@v4
+      - name: Upload sha1 as artifact
+        uses: actions/upload-artifact@v4
         with:
-          name: release_url
-      - name: Get Release File Name & Upload URL
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: get_release_info
-        shell: bash
-        run: |
-          value=`cat release_url.txt`
-          echo "upload_url=$value" >> $GITHUB_OUTPUT
-      - name: Upload Release Asset
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/vcpkg/installed/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
-          asset_name: openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
-          asset_content_type: application/zip
+          name: openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip.sha1
+          path: ${{ github.workspace }}/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip.sha1
   macos-build:
     name: macOS
     runs-on: macos-14
@@ -161,26 +132,38 @@ jobs:
         with:
           name: openrct2-libs-v${{ env.version }}-universal-macos-dylibs.zip
           path: openrct2-libs-v${{ env.version }}-universal-macos-dylibs.zip
-      - name: Load Release URL File from release job
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [windows, macos-package]
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Get the version
         if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: release_url
-      - name: Get Release File Name & Upload URL
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: get_release_info
-        shell: bash
+          merge-multiple: true
+      - name: Concatenate sha1 files
         run: |
-          value=`cat release_url.txt`
-          echo "upload_url=$value" >> $GITHUB_OUTPUT
-      - name: Upload Release Asset
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ls -lR
+          pushd ${{ github.workspace }}
+          sha1sum openrct2-libs-v${{ env.version }}-*.zip > openrct2-libs-v${{ env.version }}-sha1sums.txt
+          popd
+      - name: Create release notes
+        run: |
+          echo "Release notes for version ${{ env.version }}" > release_notes.txt
+          echo "" >> release_notes.txt
+          echo "SHA1 checksums:" >> release_notes.txt
+          echo "\`\`\`" >> release_notes.txt
+          cat openrct2-libs-v${{ needs.get_version.outputs.version }}-sha1sums.txt >> release_notes.txt
+          echo "\`\`\`" >> release_notes.txt
+          echo "" >> release_notes.txt
+      - name: Create release
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: openrct2-libs-v${{ env.version }}-universal-macos-dylibs.zip
-          asset_name: openrct2-libs-v${{ env.version }}-universal-macos-dylibs.zip
-          asset_content_type: application/zip
+          files: |
+            openrct2-libs-v${{ env.version }}-sha1sums.txt
+            openrct2-libs-v${{ env.version }}-*.zip
+          body_path: release_notes.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,32 @@ on: [push, pull_request]
 env:
   VCPKG_COMMIT_HASH: 68d349964cb4e8da561fd849d9491e6ba11c5681
 jobs:
-  createrelease:
-    name: createrelease
+  get_version:
+    name: Get version
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Get the version
         id: get_version
-        run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+        run: |
+          # check if git ref matches a tag
+          if [[ "$GITHUB_REF" =~ "refs/tags/v" ]]; then
+            TAG=${GITHUB_REF/refs\/tags\/v/}
+            echo setting output to tag $TAG
+            echo "version=$TAG" >> "$GITHUB_OUTPUT"
+          else
+            # set version to sha1 of the commit
+            echo setting output to $GITHUB_SHA
+            echo "version=$GITHUB_SHA" >> $GITHUB_OUTPUT
+          fi
+          echo Output: \"$GITHUB_OUTPUT\"
   windows:
     name: Windows
     runs-on: windows-latest
-    needs: createrelease
+    needs: get_version
     if: always()
     strategy:
       fail-fast: false
@@ -28,11 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Get the version
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          chcp 65001 #set code page to utf-8
-          echo ("version=" + $env:GITHUB_REF.replace('refs/tags/v', '')) >> $env:GITHUB_ENV
       - uses: lukka/get-cmake@latest
       - name: Install vcpkg and packages
         uses: lukka/run-vcpkg@v11
@@ -46,27 +53,27 @@ jobs:
       - name: Zip stuff
         run: |
           pushd ${{ github.workspace }}/vcpkg/installed/${{ matrix.triplet }}/${{ matrix.triplet }}
-          7z a -tzip -mx9 -mtc=off ../../openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip "*"
+          7z a -tzip -mx9 -mtc=off ../../openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}.zip "*"
           popd
       - name: Export checksum info for release notes
         run: |
           pushd ${{ github.workspace }}/vcpkg
-          sha1sum installed/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip > ../openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip.sha1
+          sha1sum installed/openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}.zip > ../openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}.zip.sha1
           popd
       - name: Upload zipped libraries as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
-          path: ${{ github.workspace }}/vcpkg/installed/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip
+          name: openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}.zip
+          path: ${{ github.workspace }}/vcpkg/installed/openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}.zip
       - name: Upload sha1 as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip.sha1
-          path: ${{ github.workspace }}/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}.zip.sha1
+          name: openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}.zip.sha1
+          path: ${{ github.workspace }}/openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}.zip.sha1
   macos-build:
     name: macOS
     runs-on: macos-14
-    needs: createrelease
+    needs: get_version
     if: always()
     strategy:
       fail-fast: false
@@ -78,9 +85,6 @@ jobs:
       # needed for vcpkg.json
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Get the version
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Install prerequisites
         shell: bash
         run: |
@@ -100,47 +104,43 @@ jobs:
       - name: Zip stuff
         run: |
           pushd ${{ github.workspace }}/vcpkg/installed/${{ matrix.triplet }}
-          zip -rXy ../openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}-macos-dylibs.zip * -x '*/.*'
+          zip -rXy ../openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}-macos-dylibs.zip * -x '*/.*'
       - name: Upload zip as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}-macos-dylibs.zip
-          path: ${{ github.workspace }}/vcpkg/installed/openrct2-libs-v${{ env.version }}-${{ matrix.triplet }}-macos-dylibs.zip
+          name: openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}-macos-dylibs.zip
+          path: ${{ github.workspace }}/vcpkg/installed/openrct2-libs-v${{ needs.get_version.outputs.version }}-${{ matrix.triplet }}-macos-dylibs.zip
 
   macos-package:
     name: macOS package universal library
     runs-on: macos-14
-    needs: macos-build
+    needs: [macos-build, get_version]
     if: always()
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Get the version
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Download All Artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: openrct2-libs-v*-macos-dylibs.zip
       - name: Create Universal Library
+        env:
+          version: ${{ needs.get_version.outputs.version }}
         run: |
-          unzip -qo openrct2-libs-v${{ env.version }}-arm64-osx-openrct2-macos-dylibs.zip/openrct2-libs-v${{ env.version }}-arm64-osx-openrct2-macos-dylibs.zip
-          unzip -qo openrct2-libs-v${{ env.version }}-x64-osx-openrct2-macos-dylibs.zip/openrct2-libs-v${{ env.version }}-x64-osx-openrct2-macos-dylibs.zip
+          unzip -qo openrct2-libs-v${{ needs.get_version.outputs.version }}-arm64-osx-openrct2-macos-dylibs.zip/openrct2-libs-v${{ needs.get_version.outputs.version }}-arm64-osx-openrct2-macos-dylibs.zip
+          unzip -qo openrct2-libs-v${{ needs.get_version.outputs.version }}-x64-osx-openrct2-macos-dylibs.zip/openrct2-libs-v${{ needs.get_version.outputs.version }}-x64-osx-openrct2-macos-dylibs.zip
           ./macos_build.sh
       - name: Upload zip as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: openrct2-libs-v${{ env.version }}-universal-macos-dylibs.zip
-          path: openrct2-libs-v${{ env.version }}-universal-macos-dylibs.zip
+          name: openrct2-libs-v${{ needs.get_version.outputs.version }}-universal-macos-dylibs.zip
+          path: openrct2-libs-v${{ needs.get_version.outputs.version }}-universal-macos-dylibs.zip
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [windows, macos-package]
+    needs: [windows, macos-package, get_version]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - name: Get the version
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: echo "version=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -149,11 +149,11 @@ jobs:
         run: |
           ls -lR
           pushd ${{ github.workspace }}
-          sha1sum openrct2-libs-v${{ env.version }}-*.zip > openrct2-libs-v${{ env.version }}-sha1sums.txt
+          sha1sum openrct2-libs-v${{ needs.get_version.outputs.version }}-*.zip > openrct2-libs-v${{ needs.get_version.outputs.version }}-sha1sums.txt
           popd
       - name: Create release notes
         run: |
-          echo "Release notes for version ${{ env.version }}" > release_notes.txt
+          echo "Release notes for version ${{ needs.get_version.outputs.version }}" > release_notes.txt
           echo "" >> release_notes.txt
           echo "SHA1 checksums:" >> release_notes.txt
           echo "\`\`\`" >> release_notes.txt
@@ -164,6 +164,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            openrct2-libs-v${{ env.version }}-sha1sums.txt
-            openrct2-libs-v${{ env.version }}-*.zip
+            openrct2-libs-v${{ needs.get_version.outputs.version }}-sha1sums.txt
+            openrct2-libs-v${{ needs.get_version.outputs.version }}-*.zip
           body_path: release_notes.txt


### PR DESCRIPTION
Rework releases:

This commit changes how releases are made. Previously a release based on
a tag was done as the first step and `actions/upload-release-asset` was
then used to submit build artifacts to it. That action, however, is
obsoleted and will stop working in the future.

The new approach first builds everything, then uses
`softprops/action-gh-release` to create the release once all the build
artifacts are collected. This allows for some handy improvements like
providing sha1sum of each build artifact.

I tried automating generating the summary of installed packages and
their versions, but all my attempts at that failed, probably due to
running vcpkg outside of `lukka/run-vcpkg` action, which maybe creates
some special environment? Setting `VCPKG_ROOT`, `VCPKG_INSTALLED_DIR`
for relevant jobs yielded no improvements.

---

Rework how version is obtained:

In previous approach version would be set in each job individually,
potentially leading to divergence. The new approach sets the version in
first step as job output, which is then consumed by all the other jobs
in the workflow.

---

I intend to implement similar flow for main OpenRCT2 repository, to address https://github.com/OpenRCT2/OpenRCT2/issues/22737